### PR TITLE
Fixes overwriting created states.

### DIFF
--- a/src/expressPresenter/tests/putState/overwriteExistingState.test.ts
+++ b/src/expressPresenter/tests/putState/overwriteExistingState.test.ts
@@ -1,13 +1,18 @@
+import * as stringToStream from 'string-to-stream';
 import assertImmutableState from '../../../utils/assertImmutableState';
 import assertState from '../../../utils/assertState';
 import createImmutableState from '../../../utils/createImmutableState';
 import createTextState from '../../../utils/createTextState';
 import {
   TEST_ACCOUNT_AGENT,
+  TEST_CONTENT,
   TEST_IMMUTABLE_CONTENT,
   TEST_MBOX_AGENT,
   TEST_MBOXSHA1_AGENT,
   TEST_OPENID_AGENT,
+  TEST_OBJECT_CONTENT,
+  TEST_OBJECT_PATCH_CONTENT,
+  JSON_CONTENT_TYPE,
  } from '../../../utils/testValues';
 import { CLIENT_ERROR_400_HTTP_CODE, NO_CONTENT_204_HTTP_CODE } from '../../utils/httpCodes';
 import setup from '../utils/setup';
@@ -23,8 +28,17 @@ describe('expressPresenter.putState with existing model', () => {
 
   it('should overwrite model when overwriting an existing model', async () => {
     await createTextState();
+    await assertState(TEST_CONTENT);
     await overwriteState({}, TEST_IMMUTABLE_CONTENT).expect(NO_CONTENT_204_HTTP_CODE);
     await assertState(TEST_IMMUTABLE_CONTENT);
+  });
+
+  it('should overwrite model when overwriting existing JSON', async () => {
+    await createTextState({ content: stringToStream(TEST_OBJECT_CONTENT)});
+    await assertState(TEST_OBJECT_CONTENT);
+    await overwriteState({}, TEST_OBJECT_PATCH_CONTENT, JSON_CONTENT_TYPE)
+      .expect(NO_CONTENT_204_HTTP_CODE);
+    await assertState(TEST_OBJECT_PATCH_CONTENT);
   });
 
   it('should overwrite model when overwriting without a registration', async () => {

--- a/src/expressPresenter/tests/putState/overwriteExistingState.test.ts
+++ b/src/expressPresenter/tests/putState/overwriteExistingState.test.ts
@@ -4,15 +4,15 @@ import assertState from '../../../utils/assertState';
 import createImmutableState from '../../../utils/createImmutableState';
 import createTextState from '../../../utils/createTextState';
 import {
+  JSON_CONTENT_TYPE,
   TEST_ACCOUNT_AGENT,
   TEST_CONTENT,
   TEST_IMMUTABLE_CONTENT,
   TEST_MBOX_AGENT,
   TEST_MBOXSHA1_AGENT,
-  TEST_OPENID_AGENT,
   TEST_OBJECT_CONTENT,
   TEST_OBJECT_PATCH_CONTENT,
-  JSON_CONTENT_TYPE,
+  TEST_OPENID_AGENT,
  } from '../../../utils/testValues';
 import { CLIENT_ERROR_400_HTTP_CODE, NO_CONTENT_204_HTTP_CODE } from '../../utils/httpCodes';
 import setup from '../utils/setup';

--- a/src/mongoModelsRepo/overwriteState.ts
+++ b/src/mongoModelsRepo/overwriteState.ts
@@ -26,7 +26,7 @@ export default (config: Config) => {
     const createOpResult = await collection.findOneAndUpdate(
       stateFilter,
       {
-        $setOnInsert: update,
+        $set: update,
       },
       {
         returnOriginal: false, // Ensures the updated document is returned.


### PR DESCRIPTION
I've added a regression test for this. Previous tests of the overwrite function didn't pick up on this because they tested with text/plain not application/json.

https://github.com/LearningLocker/learninglocker/issues/1016